### PR TITLE
Bad URL redirects to main page with flash error now

### DIFF
--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -50,7 +50,12 @@ class RoomsController < ApplicationController
 
   def find_room
     @url = params[:short_url]
-    @room = Room.find_by(short_url: @url) or not_found
+    @room = Room.find_by(short_url: @url)
+
+    unless @room
+      flash[:error] = "Could not find room: #{params[:short_url]}"
+      redirect_to root_path and return
+    end
   end
 
   def delete_room_if_last_user(room_id)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
-  root 'static#home'
+  root 'static#home', as: 'root'
 
   post '/:short_url/auth', to: 'rooms#authenticate', as: 'authenticate'
   get '/:short_url', to: 'rooms#index', as: 'view_room'

--- a/test/controllers/rooms_controller_test.rb
+++ b/test/controllers/rooms_controller_test.rb
@@ -73,9 +73,20 @@ class RoomsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to new_user_path
   end
 
-  test 'GET to index with invalid short_url returns 404' do
+  test 'GET to index with invalid short_url redirects to root' do
     init_user
-    assert_raises(ActionController::RoutingError) { get view_room_path(short_url: "x") }
+
+    get view_room_path(short_url: "x")
+
+    assert_redirected_to root_path
+  end
+
+  test 'GET to index with invalid short_url shows helpful flash message' do
+    init_user
+
+    get view_room_path(short_url: "x")
+
+    assert_equal flash[:error], "Could not find room: x"
   end
 
   test 'GET to index with valid short_url returns success' do


### PR DESCRIPTION
Now if a user searches for a room that doesn't exist or tries to visit site.com/BAD_ROOM_CODE, instead of showing a generic 404 we tell them their room code is bad.