### PR TITLE
Fix short_url capitalization issue

### DIFF
--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -54,7 +54,7 @@ class RoomsController < ApplicationController
   end
 
   def find_room
-    @url = params[:short_url]
+    @url = params[:short_url].upcase
     @room = Room.find_by(short_url: @url)
 
     unless @room

--- a/test/controllers/rooms_controller_test.rb
+++ b/test/controllers/rooms_controller_test.rb
@@ -103,6 +103,13 @@ class RoomsControllerTest < ActionDispatch::IntegrationTest
     assert_template :index
   end
 
+  test 'GET to index with valid short_url but wrong capitalization renders index' do
+    @public_room.users << init_user
+    get view_room_path(short_url: @public_room.short_url.downcase)
+
+    assert_template :index
+  end
+
   test 'GET to index with valid short_url to public room user is not in adds user' do
     user = init_user
     get view_room_path(short_url: @public_room.short_url)


### PR DESCRIPTION
Closes #11 

Rooms can now be joined if the short_url is not capitalized correctly.