### PR TITLE
Messages now render correctly

### DIFF
--- a/app/assets/javascripts/rooms.coffee
+++ b/app/assets/javascripts/rooms.coffee
@@ -27,6 +27,19 @@ jQuery(document).on 'turbolinks:load', ->
         console.log('We are now disconnected')
 
       received: (data) ->
+        self_id = messages.data('user-id')
+        if self_id == data['userid']
+          if data['type'] == 'their'
+            return
+          else if (((messages[0].lastElementChild.className.search(/your/) != -1) == data['name']))
+            return
+
+        else
+          if data['type'] == 'your'
+            return
+          else if ((messages[0].lastElementChild.className.search(/their/) != -1) == (data['name']))
+            return
+
         if window.lastMessage
           window.lastMessage = false
         else

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -13,7 +13,7 @@ module ApplicationCable
       cookies.encrypted[Rails.application.config.session_options[:key]]
     end
 
-    def find_verified_user # this checks whether a user is authenticated with devise
+    def find_verified_user
       if verified_user = User.find_by(id: session["user_id"])
         verified_user
       else

--- a/app/jobs/message_broadcast_job.rb
+++ b/app/jobs/message_broadcast_job.rb
@@ -1,15 +1,45 @@
 class MessageBroadcastJob < ApplicationJob
   queue_as :default
 
+  # Hack to deal with different message templates on the client side.
   def perform(message)
     ActionCable.server.broadcast "rooms_#{message.room.id}_channel",
-                                 message: render_message(message)
+                                 message: their_message(message),
+                                 type: 'their',
+                                 name: false,
+                                 userid: message.user.id
+    ActionCable.server.broadcast "rooms_#{message.room.id}_channel",
+                                 message: their_message_name(message),
+                                 type: 'their',
+                                 name: true,
+                                 userid: message.user.id
+   ActionCable.server.broadcast "rooms_#{message.room.id}_channel",
+                                 message: your_message(message),
+                                 type: 'your',
+                                 name: false,
+                                 userid: message.user.id
+    ActionCable.server.broadcast "rooms_#{message.room.id}_channel",
+                                 message: your_message_name(message),
+                                 type: 'your',
+                                 name: true,
+                                 userid: message.user.id
   end
 
   private
 
-  def render_message(message)
+  def their_message_name(message)
+    MessagesController.render partial: 'messages/their_message', locals: {message: message, skip_name: false}
+  end
+
+  def their_message(message)
     MessagesController.render partial: 'messages/their_message', locals: {message: message, skip_name: true}
+  end
+
+  def your_message_name(message)
+    MessagesController.render partial: 'messages/your_message', locals: {message: message, skip_name: false}
+  end
+
+  def your_message(message)
     MessagesController.render partial: 'messages/your_message', locals: {message: message, skip_name: true}
   end
 end

--- a/app/views/rooms/index.html.erb
+++ b/app/views/rooms/index.html.erb
@@ -4,7 +4,7 @@
 <div class='room-index-flex-container'>
   <div class='left-container'>
     <div class='messages-container'>
-      <div id="message-container" data-room-id="<%= @room.id %>">
+      <div id="message-container" data-room-id="<%= @room.id %>" data-user-id="<%= @user.id %>">
         <%= render 'messages' %>
       </div>
       <div id='message-container-loading'>


### PR DESCRIPTION
Messages can either be rendered as a user's message without a name, user's message with a name, other's message with name, or other's without. Unfortunately with the current setup, we can't pass message info to the client and have it render the correct template. 

My hack is to send all 4 templates and let the client choose the correct one. A better solution, something I'd like to do eventually, is setup channels for each room/user combination, then send the correct template based on the room and recieving user instead of broadcasting the same templates to all room users.