### PR TITLE
Inheritance structure set up

### DIFF
--- a/app/assets/javascripts/rooms.coffee
+++ b/app/assets/javascripts/rooms.coffee
@@ -63,7 +63,7 @@ jQuery(document).on 'turbolinks:load', ->
         container.animate({ scrollTop: container.prop("scrollHeight")}, 1000);
 
       send_message: (message, room_id) ->
-        @perform 'send_message', message: message, room_id: room_id
+        @perform 'send_message', content: message, room_id: room_id
 
     $('#newMessage').submit (e) ->
       $this = $(this)

--- a/app/channels/rooms_channel.rb
+++ b/app/channels/rooms_channel.rb
@@ -11,7 +11,10 @@ class RoomsChannel < ApplicationCable::Channel
 
   def send_message(data)
     (return false) unless current_user.room_id == data['room_id']
-    current_user.messages.create!(content: data['message'], room_id: data['room_id'])
+
+    message = current_user.messages.new(room_id: data['room_id'])
+    message.set_content('TextMessage', data['content'])
+    message.save
   end
 
   private

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -3,11 +3,9 @@ class MessagesController < ApplicationController
     message = Message.new(
       room_id: params['room_id'],
       user_id: params['user_id'],
-      content: params['message']['content']
+      content: params['message']
     )
-
-    message.save
-
+    
     respond_to do |format|
       format.html
       format.js

--- a/app/jobs/message_broadcast_job.rb
+++ b/app/jobs/message_broadcast_job.rb
@@ -13,20 +13,4 @@ class MessageBroadcastJob < ApplicationJob
   def mix_message(message)
     MessagesController.render partial: 'messages/mix_messages', locals: {message: message}
   end
-
-  def their_message_name(message)
-    MessagesController.render partial: 'messages/their_message', locals: {message: message, skip_name: false}
-  end
-
-  def their_message(message)
-    MessagesController.render partial: 'messages/their_message', locals: {message: message, skip_name: true}
-  end
-
-  def your_message_name(message)
-    MessagesController.render partial: 'messages/your_message', locals: {message: message, skip_name: false}
-  end
-
-  def your_message(message)
-    MessagesController.render partial: 'messages/your_message', locals: {message: message, skip_name: true}
-  end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -2,5 +2,34 @@ class Message < ApplicationRecord
   belongs_to :room
   belongs_to :user
 
+  validates :content_klass, presence: true
+  validate :is_valid_klass
+
+  validates :content_id, presence: true
+
   after_create_commit { MessageBroadcastJob.perform_later(self) }
+
+  def set_content(type, content)
+    message_content = type.constantize.data_to_obj(content)
+
+    self.content_klass = type
+    self.content_id = message_content.id
+  end
+
+  def render
+    content_object = self[:content_klass].constantize.find_by(id: self[:content_id])
+    return "" unless content_object
+
+    content_object.render
+  end
+
+  def is_valid_klass
+    klass = self[:content_klass].constantize
+    unless klass && klass.method_defined?(:render)
+      errors.add(:content_klass, "Content class is not valid")
+    end
+
+  rescue
+    errors.add(:content_klass, "Content class is not valid")
+  end
 end

--- a/app/models/text_message.rb
+++ b/app/models/text_message.rb
@@ -1,0 +1,13 @@
+class TextMessage < ApplicationRecord
+  validates :content, presence: true, length: { maximum: 2000 }
+
+  class << self
+    def data_to_obj(data)
+      TextMessage.create(content: data)
+    end
+  end
+
+  def render
+    self[:content] || ""
+  end
+end

--- a/app/views/messages/_their_message.html.erb
+++ b/app/views/messages/_their_message.html.erb
@@ -5,6 +5,6 @@
     </div>
   <% end %>
   <div class='message their-message'>
-    <%= message.content %>
+    <%= message.render %>
   </div>
 </div>

--- a/app/views/messages/_your_message.html.erb
+++ b/app/views/messages/_your_message.html.erb
@@ -5,6 +5,6 @@
     </div>
   <% end %>
   <div class='message your-message'>
-    <%= message.content %>
+    <%= message.render %>
   </div>
 </div>

--- a/db/migrate/20170129190433_create_text_messages.rb
+++ b/db/migrate/20170129190433_create_text_messages.rb
@@ -1,0 +1,8 @@
+class CreateTextMessages < ActiveRecord::Migration[5.0]
+  def change
+    create_table :text_messages do |t|
+      t.string :content, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20170129192622_remove_content_from_message.rb
+++ b/db/migrate/20170129192622_remove_content_from_message.rb
@@ -1,0 +1,5 @@
+class RemoveContentFromMessage < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :messages, :content, :string
+  end
+end

--- a/db/migrate/20170129193331_add_owner_type_and_id.rb
+++ b/db/migrate/20170129193331_add_owner_type_and_id.rb
@@ -1,0 +1,6 @@
+class AddOwnerTypeAndId < ActiveRecord::Migration[5.0]
+  def change
+    add_column :messages, :content_klass, :string
+    add_column :messages, :content_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170118060614) do
+ActiveRecord::Schema.define(version: 20170129193331) do
 
   create_table "messages", force: :cascade do |t|
-    t.integer  "room_id",                 null: false
-    t.integer  "user_id",                 null: false
-    t.string   "content",    default: ""
-    t.datetime "created_at",              null: false
-    t.datetime "updated_at",              null: false
+    t.integer  "room_id",       null: false
+    t.integer  "user_id",       null: false
+    t.datetime "created_at",    null: false
+    t.datetime "updated_at",    null: false
+    t.string   "content_klass"
+    t.integer  "content_id"
   end
 
   create_table "rooms", force: :cascade do |t|
@@ -29,6 +30,12 @@ ActiveRecord::Schema.define(version: 20170118060614) do
     t.string   "encrypted_password"
     t.string   "salt"
     t.index ["short_url"], name: "index_rooms_on_short_url"
+  end
+
+  create_table "text_messages", force: :cascade do |t|
+    t.string   "content",    null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "users", force: :cascade do |t|

--- a/test/fixtures/text_messages.yml
+++ b/test/fixtures/text_messages.yml
@@ -1,0 +1,5 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -20,15 +20,26 @@ class MessageTest < ActiveSupport::TestCase
     assert message.errors['room']
   end
 
-  test "room is valid with room and user" do
+  test "invalid if does not have content" do
     message = Message.new(room: @room, user: @user)
+
+    refute message.save
+    assert message.errors['conent_klass']
+  end
+
+  test 'valid if we set content correctly' do
+    message = Message.new(room: @room, user: @user)
+    message.set_content('TextMessage', 'Hello')
 
     assert message.save
   end
 
-  test "room message defaults to empty string" do
-    message = Message.create(room: @room, user: @user)
+  test 'message renders correctly' do
+    message = Message.new(room: @room, user: @user)
+    message.set_content('TextMessage', 'Hello')
 
-    assert_equal message.content, ""
+    message.save
+
+    assert_equal message.render, 'Hello'
   end
 end

--- a/test/models/text_message_test.rb
+++ b/test/models/text_message_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+
+class TextMessageTest < ActiveSupport::TestCase
+  test "content length max enforced" do
+    message = TextMessage.new(content: 'x'*2001)
+
+    refute message.save
+    assert message.errors[:content]
+  end
+
+  test "saves correctly" do
+    message = TextMessage.new(content: 'Hello')
+
+    assert message.save
+  end
+
+  test "data_to_obj saves to database" do
+    TextMessage.data_to_obj('Hello')
+
+    assert_equal TextMessage.last.content, 'Hello'
+  end
+
+  test 'render returns correct text' do
+    message = TextMessage.new(content: 'Hello')
+
+    assert_equal message.render, 'Hello'
+  end
+end


### PR DESCRIPTION
Messages now follow a multi-table inheritance structure.

A Message has a content class which is any class that can respond to 'render'.

It stores it's content as a content_klass string and a content_id integer. These uniquely identify the object that represents the messages content. The Message does not care about what type of content it has, it just needs to be able to render the message content.

Added TextMessage as the first basic message type.